### PR TITLE
Step into broadcast calls

### DIFF
--- a/src/debug.jl
+++ b/src/debug.jl
@@ -197,8 +197,13 @@ function prepare_caller_capture!(io)  # for testing, needs to work on a normal I
     elseif callexpr.head == :...
         callexpr = callexpr.args[1]
     end
-    callexpr.head == :call || throw(Meta.ParseError("point must be at a call expression, got $callexpr"))
-    fname, args = callexpr.args[1], callexpr.args[2:end]
+    # Must be a call or broadcast
+    ((callexpr.head == :call) | (callexpr.head == :.)) || throw(Meta.ParseError("point must be at a call expression, got $callexpr"))
+    if callexpr.head == :call
+        fname, args = callexpr.args[1], callexpr.args[2:end]
+    else
+        fname, args = :broadcast, [callexpr.args[1], callexpr.args[2].args...]
+    end
     # In the edited callstring separate any kwargs now. They don't affect dispatch.
     kwargs = []
     if length(args) >= 1 && isa(args[1], Expr) && args[1].head == :parameters

--- a/src/ui.jl
+++ b/src/ui.jl
@@ -156,7 +156,11 @@ function HeaderREPLs.print_header(io::IO, header::RebugHeader)
             printer(args...) = printstyled(args..., '\n'; color=:light_blue)
             for (name, val) in zip(data.varnames, data.varvals)
                 # Make sure each only spans one line
-                Revise.printf_maxsize(printer, s, "  ", name, " = ", val; maxlines=1, maxchars=ds[2]-1)
+                try
+                    Revise.printf_maxsize(printer, s, "  ", name, " = ", val; maxlines=1, maxchars=ds[2]-1)
+                catch # don't error just because a print method is borked
+                    printstyled(s, "  ", name, " errors in its show method"; color=:red)
+                end
             end
         end
     end

--- a/test/testmodule.jl
+++ b/test/testmodule.jl
@@ -3,6 +3,7 @@ module RebuggerTesting
 const cbdata1 = Ref{Any}(nothing)
 const cbdata2 = Ref{Any}(nothing)
 
+# Do not alter the line number at which `foo` occurs
 foo(x, y) = nothing
 
 snoop0()             = snoop1("Spy")


### PR DESCRIPTION
Also prevents a really nasty error that crops up if variables displayed in the header happen to have an error in their `show` method.