### PR TITLE
Allow users to add custom keybindings.

### DIFF
--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -1,5 +1,7 @@
 # Configuration
 
+## Run on REPL startup
+
 If you decide you like Rebugger, you can add lines such as the following to your
 `~/.julia/config/startup.jl` file:
 
@@ -20,3 +22,54 @@ catch
     @warn "Could not turn on Rebugger key bindings."
 end
 ```
+
+## Customize keybindings
+
+It's possible that Rebugger's default keybindings don't work for you.
+This can be for various reasons. Some window managers override the Rebugger's
+keybindings with their own. Some terminals map the keybindings used by Rebugger
+to different escape sequences than those hardcoded in Rebugger. You can work
+around these issues by adding your own keybindings.
+
+To add your own keybindings, use `Rebugger.add_keybindings(action=keybinding, ...)`.
+This can be done during a running Rebugger session. Here is an example that
+maps the "step in" action to the key "F5":
+```julia
+julia> Rebugger.add_keybindings(stepin="\e[17~", stacktrace="\e[18~")
+```
+
+To make your keybindings permanent, add them to your `startup.jl` file like so:
+```julia
+try
+    @eval using Revise
+    # Turn on Revise's file-watching behavior
+    Revise.async_steal_repl_backend()
+catch
+    @warn "Could not load Revise."
+end
+
+try
+    @eval using Rebugger
+    # Activate Rebugger's key bindings
+    Rebugger.keybindings[:stepin] = "\e[17~"  # Add the keybinding F6 to step into a function.
+    Rebugger.keybindings[:stacktrace] = "\e[18~"  # Add the keybinding F7 to print a stacktrace.
+    atreplinit(Rebugger.repl_init)
+catch
+    @warn "Could not load Rebugger."
+end
+```
+
+But how to find out the cryptic string that corresponds to the keybinding you
+want? Use Julia's `read()` function:
+
+```julia
+julia> str = read(stdin, String)
+^[[17~"\e[17~"  # Press F6
+
+julia> str
+"\e[17~"
+```
+
+After calling `read()`, press the keybinding that you want. Then, press `Ctrl+D`
+twice to terminate the input. The value of `str` is the cryptic string you are
+looking for.

--- a/src/Rebugger.jl
+++ b/src/Rebugger.jl
@@ -20,7 +20,7 @@ include("deepcopy.jl")
 # Set up keys that enter rebug mode from the regular Julia REPL
 # This should be called from your ~/.julia/config/startup.jl file
 function repl_init(repl)
-    repl.interface = REPL.setup_interface(repl; extra_repl_keymap = rebugger_modeswitch)
+    repl.interface = REPL.setup_interface(repl; extra_repl_keymap = get_rebugger_modeswitch_dict())
 end
 
 function __init__()
@@ -34,18 +34,9 @@ function __init__()
         # Set up the custom "rebug" REPL
         main_repl = Base.active_repl
         repl = HeaderREPL(main_repl, RebugHeader())
-        interface = REPL.setup_interface(repl; extra_repl_keymap=[rebugger_modeswitch, rebugger_keys])
+        interface = REPL.setup_interface(repl; extra_repl_keymap=[get_rebugger_modeswitch_dict(), rebugger_keys])
         rebug_prompt_ref[] = interface.modes[end]
-        # Add F5 to the history prompt
-        history_prompt = find_prompt(main_repl.interface, LineEdit.PrefixHistoryPrompt)
-        add_key_stacktrace!(history_prompt.keymap_dict)
-        # If the REPL was already initialized, add the keys to the julia> prompt now
-        # (This will already be done if the user turned on the key bindings in her startup.jl file)
-        if repl_inited
-            julia_prompt = find_prompt(main_repl.interface, "julia")
-            add_key_stacktrace!(julia_prompt.keymap_dict)
-            add_key_stepin!(julia_prompt.keymap_dict)
-        end
+        add_keybindings(; override=repl_inited, keybindings...)
     end
 end
 


### PR DESCRIPTION
Making keybindings that work for every OS-Terminal combination is
nearly impossible. Allow users to add custom keybindings, so they can
work around weird system setups and experience the joy of rebugging.

Fixes #14.
Fixes #15.