### PR TITLE
Better default keybindings on windows

### DIFF
--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -60,8 +60,8 @@ end
 ```
 
 But how to find out the cryptic string that corresponds to the keybinding you
-want? Either use Julia's `read()` function as demonstrated below or refer to
-the [relevant section in Julia's manual](https://docs.julialang.org/en/stable/stdlib/REPL/#Key-bindings-1).
+want? Either refer tothe [relevant section in Julia's manual](https://docs.julialang.org/en/stable/stdlib/REPL/#Key-bindings-1) or --
+if you're on Linux or MacOS --  use Julia's `read()` function:
 
 ```julia
 julia> str = read(stdin, String)

--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -60,7 +60,8 @@ end
 ```
 
 But how to find out the cryptic string that corresponds to the keybinding you
-want? Use Julia's `read()` function:
+want? Either use Julia's `read()` function as demonstrated below or refer to
+the [relevant section in Julia's manual](https://docs.julialang.org/en/stable/stdlib/REPL/#Key-bindings-1).
 
 ```julia
 julia> str = read(stdin, String)

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -2,8 +2,8 @@
 
 Rebugger works from Julia's native REPL prompt. Currently there are two important keybindings:
 
-- Alt-Shift-Enter maps to "step in"
-- F5 maps to "capture stacktrace" (for commands that throw an error)
+- `Alt-Shift-Enter` (`Alt-E` on Windows) maps to "step in"
+- `F5` (`Alt-S` on Windows) maps to "capture stacktrace" (for commands that throw an error)
 
 ## Stepping in
 
@@ -200,4 +200,3 @@ The interactive stacktrace visits only those methods that appear in the original
 !!! note
     `Pkg` is one of Julia's standard libraries, and to step into or trace Julia's stdlibs
     you must build Julia from source.
-

--- a/src/ui.jl
+++ b/src/ui.jl
@@ -233,8 +233,8 @@ function HeaderREPLs.activate_header(header::RebugHeader, p, s, termbuf, term)
 end
 
 const keybindings = Dict{Symbol,String}(
-    :stacktrace => "\e[15~",  # F5
-    :stepin => "\e\eOM",  # Alt-Shift-Enter
+    :stacktrace => Sys.iswindows() ? "\x1bs" : "\e[15~",  # Alt-s or F5
+    :stepin => Sys.iswindows() ? "\x1be" : "\e\eOM",  # Alt-e or Alt-Shift-Enter
     :deprecated_stepin => "\e[23~",  # F11
 )
 


### PR DESCRIPTION
This means that the user doesn't have to change configuration at all on Windows to get Rebugger working.

Also adjusted the docs a bit since the `read(stdin, String)` method for getting keybindings doesn't work on Windows.