### PR TITLE
Better handling of stacktraces

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.7
-Revise 0.7.3
+Revise 0.7.15
 HeaderREPLs 0.2

--- a/src/debug.jl
+++ b/src/debug.jl
@@ -169,6 +169,7 @@ function capture_stacktrace(mod::Module, command::Expr)
     end
     errored || error("$command did not throw an error")
     usrtrace, defs = pregenerated_stacktrace(trace)
+    isempty(usrtrace) && error("failed to capture any elements of the stacktrace")
     println(stderr, "Captured elements of stacktrace:")
     show(stderr, MIME("text/plain"), usrtrace)
     length(unique(usrtrace)) == length(usrtrace) || @error "the same method appeared twice, not supported. Try stepping into the command."

--- a/src/debug.jl
+++ b/src/debug.jl
@@ -88,27 +88,55 @@ and so on.
 function pregenerated_stacktrace(trace; topname = :capture_stacktrace)
     usrtrace, defs = Method[], RelocatableExpr[]
     methodsused = Set{Method}()
+
+    function load_file(file, mod=Base)
+        ret = Revise.find_file(file, mod)
+        ret == nothing && return nothing
+        file, recipemod = ret
+        if !haskey(Revise.fileinfos, file)
+            try
+                @info "tracking $recipemod"
+                Revise.track(recipemod)
+            catch err
+                err isa Revise.GitRepoException && return nothing
+                rethrow(err)
+            end
+        end
+        return file
+    end
+
+    # When the method can't be found directly in the tables,
+    # look it up by fie and line number
+    function add_by_file_line(defmap, sf)
+        for (def, info) in defmap
+            info == nothing && continue
+            sigts, offset = info
+            r = linerange(def, offset)
+            r == nothing && continue
+            if sf.line ∈ r
+                mths = Base._methods_by_ftype(last(sigts), -1, typemax(UInt))
+                m = mths[end][3]    # the last method is the least specific that matches the signature (which would be more specific if it were used)
+                if m ∉ methodsused
+                    push!(defs, def)
+                    push!(usrtrace, m)
+                    push!(methodsused, m)
+                    return true
+                end
+            end
+        end
+        return false
+    end
+
     for (i, sf) in enumerate(trace)
         sf.func == topname && break  # truncate at the chosen spot
         sf.func ∈ notrace && continue
         mi = sf.linfo
+        file = String(sf.file)
         if mi isa Core.MethodInstance
             method = mi.def
             # Set up tracking, if necessary
-            file = String(sf.file)
             if !haskey(Revise.fileinfos, file)
-                ret = Revise.find_file(file, method.module)
-                ret == nothing && continue
-                file, recipemod = ret
-                if !haskey(Revise.fileinfos, file)
-                    try
-                        @info "tracking $recipemod"
-                        Revise.track(recipemod)
-                    catch err
-                        err isa Revise.GitRepoException && continue
-                        rethrow(err)
-                    end
-                end
+                file = load_file(file, method.module)
             end
             haskey(Revise.fileinfos, file) || continue
             fi = Revise.fileinfos[file]
@@ -118,30 +146,24 @@ function pregenerated_stacktrace(trace; topname = :capture_stacktrace)
                 # This is a generated method, perhaps it's a keyword function handler
                 # Look for it by line number
                 defmap = fi.fm[method.module].defmap
-                for (def, info) in defmap
-                    info == nothing && continue
-                    sigts, offset = info
-                    r = linerange(def, offset)
-                    r == nothing && continue
-                    if sf.line ∈ r
-                        mths = Base._methods_by_ftype(last(sigts), -1, typemax(UInt))
-                        if length(mths) == 1
-                            m = mths[1][3]
-                            if m ∉ methodsused
-                                push!(defs, def)
-                                push!(usrtrace, m)
-                                push!(methodsused, m)
-                                break
-                            end
-                        end
-                    end
-                end
+                add_by_file_line(defmap, sf)
             else
                 method ∈ methodsused && continue
                 def = Revise.get_def(method; modified_files=String[])
                 def isa ExLike || continue
                 push!(defs, def)
                 push!(usrtrace, method)
+            end
+        else
+            # This method was inlined and hence linfo was not available
+            if !haskey(Revise.fileinfos, file)
+                file = load_file(file)
+            end
+            haskey(Revise.fileinfos, file) || continue
+            fi = Revise.fileinfos[file]
+            Revise.maybe_parse_from_cache!(fi, file)
+            for (mod, fmm) in fi.fm
+                add_by_file_line(fmm.defmap, sf) && break
             end
         end
     end

--- a/src/ui.jl
+++ b/src/ui.jl
@@ -133,7 +133,13 @@ function capture_stacktrace(s)
     add_history(s, cmdstring)
     print(REPL.terminal(s), '\n')
     expr = Meta.parse(cmdstring)
-    uuids = capture_stacktrace(expr)
+    local uuids
+    try
+        uuids = capture_stacktrace(expr)
+    catch err
+        print(stderr, err)
+        return nothing
+    end
     io = IOBuffer()
     buf = FakePrompt(io)
     hp = mode(s).hist

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -310,7 +310,8 @@ Base.show(io::IO, ::ErrorsOnShow) = throw(ArgumentError("no show"))
             st = try RebuggerTesting.kwfunctop(3) catch; stacktrace(catch_backtrace()) end
             usrtrace, defs = Rebugger.pregenerated_stacktrace(st; topname=Symbol("macro expansion"))
             @test length(unique(usrtrace)) == length(usrtrace)
-            @test usrtrace[1] == @which RebuggerTesting.kwfuncmiddle(1,1)
+            m = @which RebuggerTesting.kwfuncmiddle(1,1)
+            @test usrtrace[1] == m || usrtrace[2] == m
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -397,7 +397,7 @@ Base.show(io::IO, ::ErrorsOnShow) = throw(ArgumentError("no show"))
                         @test countlines(io) >= 4
                     end
                     histdel += length(idx)
-                    @test length(idx) == 4
+                    @test length(idx) >= 5
                     @test hist.history[idx[1]] == cmd
                     @test occursin("error", hist.history[idx[end]])
                 end


### PR DESCRIPTION
This seems to provide significantly better "coverage" of methods in stacktraces. As of a few days ago trying to catch a stacktrace from `[1,2,3] .* [1,2]` resulted in an empty trace; with this, every method is caught.