### PR TITLE
Support do blocks

### DIFF
--- a/src/debug.jl
+++ b/src/debug.jl
@@ -354,6 +354,12 @@ function prepare_caller_capture!(io)  # for testing, needs to work on a normal I
         callexpr = callexpr.args[1]
     elseif callexpr.head == :...
         callexpr = callexpr.args[1]
+    elseif callexpr.head == :do
+        callexpr = Expr(
+            :call,
+            callexpr.args[1].args[1],         # function name
+            callexpr.args[2],                 # do block (anonymous function)
+            callexpr.args[1].args[2:end]...)  # other arguments
     end
     # Must be a call or broadcast
     ((callexpr.head == :call) | (callexpr.head == :.)) || throw(Meta.ParseError("point must be at a call expression, got $callexpr"))

--- a/test/testmodule.jl
+++ b/test/testmodule.jl
@@ -27,6 +27,15 @@ const hv_test = HasValue(11.1)
 @noinline kwfuncmiddle(x::T, y::Integer=1; kw1="hello", kwargs...) where T = kwfuncerr(y)
 @inline kwfunctop(x; kwargs...) = kwfuncmiddle(x, 2; kwargs...)
 
+function apply(f, args...)
+    kwvarargs(f)
+    f(args...)
+end
+
+calldo() = apply(2, 3, 4) do x, y, z
+    snoop3(x, y, z)
+end
+
 end
 
 module RBT2


### PR DESCRIPTION
This patch adds a support (and a test) for `do` blocks simply by pre-processing the expression into `:call`.