### PR TITLE
Update to the new Revise

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 1.0
 Revise 1.0.2
 HeaderREPLs 0.2
+CodeTracking

--- a/src/Rebugger.jl
+++ b/src/Rebugger.jl
@@ -6,9 +6,8 @@ import REPL.LineEdit, REPL.Terminals
 using REPL.LineEdit: buffer, bufend, content, edit_splice!
 using REPL.LineEdit: transition, terminal, mode, state
 
-using Revise
-using Revise: ExLike, RelocatableExpr, get_signature, funcdef_body, get_def, striplines!
-using Revise: printf_maxsize
+using CodeTracking, Revise
+using Revise: RelocatableExpr, striplines!, printf_maxsize, whichtt, hasfile, unwrap
 using HeaderREPLs
 
 const msgs = []  # for debugging. The REPL-magic can sometimes overprint error messages

--- a/src/ui.jl
+++ b/src/ui.jl
@@ -193,7 +193,7 @@ function HeaderREPLs.print_header(io::IO, header::RebugHeader)
                     val = "nothing"
                 end
                 try
-                    Revise.printf_maxsize(printer, s, "  ", name, " = ", val; maxlines=1, maxchars=ds[2]-1)
+                    printf_maxsize(printer, s, "  ", name, " = ", val; maxlines=1, maxchars=ds[2]-1)
                 catch # don't error just because a print method is borked
                     printstyled(s, "  ", name, " errors in its show method"; color=:red)
                 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -335,7 +335,7 @@ Base.show(io::IO, ::ErrorsOnShow) = throw(ArgumentError("no show"))
             usrtrace, defs = Rebugger.pregenerated_stacktrace(st; topname=Symbol("macro expansion"))
             @test length(unique(usrtrace)) == length(usrtrace)
             m = @which RebuggerTesting.kwfuncmiddle(1,1)
-            @test usrtrace[1] == m || usrtrace[2] == m
+            @test m ∈ usrtrace
 
             # A case that tests inlining and several other aspects of argument capture
             ex = :([1, 2, 3] .* [1, 2])


### PR DESCRIPTION
This is the companion to https://github.com/timholy/Revise.jl/pull/243. It doesn't (yet) offer any dramatic new functionality, but the key advantage is that it actually works most of the time :smile:. In particular, older versions of Rebugger struggled mightily with keyword-argument functions, constructors, closures, `@eval`-defined functions, generated functions, and the like. Most or all of these should be ironed out in this version.